### PR TITLE
Refactor Causal Mask Generation for Simplicity

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -86,5 +86,4 @@ class BilingualDataset(Dataset):
         }
     
 def causal_mask(size):
-    mask = torch.triu(torch.ones((1, size, size)), diagonal=1).type(torch.int)
-    return mask == 0
+    return torch.tril(torch.ones((1, size, size), dtype=torch.int))


### PR DESCRIPTION
I updated the causal_mask function to create a lower triangular matrix using torch.tril, which is more concise and clearer than inverting a mask generated with torch.triu. The functionality of the code is preserved. I hope this helps :)