### PR TITLE
Fix Layernorm Implementation

### DIFF
--- a/model.py
+++ b/model.py
@@ -15,9 +15,9 @@ class LayerNormalization(nn.Module):
          # Keep the dimension for broadcasting
         mean = x.mean(dim = -1, keepdim = True) # (batch, seq_len, 1)
         # Keep the dimension for broadcasting
-        std = x.std(dim = -1, keepdim = True) # (batch, seq_len, 1)
+        var = x.var(dim = -1, keepdim = True) # (batch, seq_len, 1)
         # eps is to prevent dividing by zero or when std is very small
-        return self.alpha * (x - mean) / (std + self.eps) + self.bias
+        return self.alpha * (x - mean) / torch.sqrt(var + self.eps) + self.bias
 
 class FeedForwardBlock(nn.Module):
 


### PR DESCRIPTION
According to the formula
norm = (x - mean) / sqrt(var + eps) not (x - mean)/(std + eps)
sqrt(var + eps) == sqrt(std**2 + eps) != (std + eps)
Though the difference may be small, it is not a strictly correct implementation of LayerNorm.